### PR TITLE
feat(recipes): add create/edit/delete flow and origin badges

### DIFF
--- a/app/api/parse-recipe/route.ts
+++ b/app/api/parse-recipe/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { RecipeSchema } from "@/lib/schemas/recipe";
+
+/**
+ * POST multipart/form-data z polem `image` (plik obrazu).
+ * Zwraca JSON zgodny z RecipeSchema.
+ *
+ * TODO (Etap 4): podłączyć Claude Vision + walidację odpowiedzi.
+ * Na razie stub — żeby UI (/recipes/new) dało się przeklikać bez backendu AI.
+ */
+export async function POST(request: NextRequest) {
+  const formData = await request.formData();
+  const file = formData.get("image");
+
+  if (!file || typeof file === "string" || !(file instanceof Blob)) {
+    return NextResponse.json({ error: "Brak pliku obrazu" }, { status: 400 });
+  }
+
+  if (!file.type.startsWith("image/")) {
+    return NextResponse.json(
+      { error: "Dozwolone są tylko pliki graficzne" },
+      { status: 400 }
+    );
+  }
+
+  const stub = {
+    title: "Zupa pomidorowa (demo ze stub API)",
+    ingredients: [
+      {
+        amount: 400,
+        unit: "g" as const,
+        customUnit: null,
+        name: "pomidorów z puszki",
+      },
+      { amount: 1, unit: "szt" as const, customUnit: null, name: "cebuli" },
+      { amount: null, unit: null, customUnit: null, name: "sól, pieprz, bazylia" },
+    ],
+    steps: [
+      { value: "Cebulę pokrój w kostkę i zeszklij na oleju." },
+      { value: "Dodaj pomidory, dopraw i gotuj 15 minut." },
+    ],
+    notes:
+      "To wypełnienie testowe z /api/parse-recipe — zamień endpoint na prawdziwy odczyt Claude.",
+  };
+
+  const parsed = RecipeSchema.safeParse(stub);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Błąd walidacji stubu" }, { status: 500 });
+  }
+
+  return NextResponse.json(parsed.data);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -128,4 +128,12 @@
   html {
     @apply font-sans;
   }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-semibold;
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,7 +16,7 @@ export default async function Home() {
     <div className="flex flex-1 flex-col items-center justify-center bg-background font-sans">
       <main className="flex max-w-3xl flex-1 flex-col items-center justify-between bg-card px-16 py-32 sm:items-start">
         <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
+          <h1 className="max-w-xs text-3xl leading-10 tracking-tight text-black dark:text-zinc-50">
             Scan and Cook
           </h1>
           <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">

--- a/app/recipes/[id]/edit/EditRecipeFormClient.tsx
+++ b/app/recipes/[id]/edit/EditRecipeFormClient.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { RecipeForm } from "@/components/RecipeForm";
+import { Button } from "@/components/ui/button";
+import { createClient } from "@/lib/supabase/client";
+import type { Recipe } from "@/lib/schemas/recipe";
+
+interface EditRecipeFormClientProps {
+  recipeId: string;
+  initialRecipe: Recipe;
+}
+
+export function EditRecipeFormClient({
+  recipeId,
+  initialRecipe,
+}: EditRecipeFormClientProps) {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const handleSubmit = async (data: Recipe) => {
+    setSaveError(null);
+    setIsSubmitting(true);
+    try {
+      const supabase = createClient();
+      const { error } = await supabase
+        .from("recipes")
+        .update({
+          title: data.title,
+          ingredients: data.ingredients,
+          steps: data.steps,
+          notes: data.notes,
+        })
+        .eq("id", recipeId);
+
+      if (error) {
+        setSaveError(error.message);
+        return;
+      }
+
+      router.push(`/recipes/${recipeId}`);
+      router.refresh();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Button asChild variant="ghost" size="sm" className="w-fit">
+          <Link href={`/recipes/${recipeId}`}>
+            <ArrowLeft className="mr-1.5 h-3.5 w-3.5" />
+            Wróć do przepisu
+          </Link>
+        </Button>
+      </div>
+
+      <div>
+        <h1 className="mb-1 text-xl">Edytuj przepis</h1>
+        <p className="text-sm text-muted-foreground">
+          Zmień treść i zapisz — data edycji zaktualizuje się automatycznie.
+        </p>
+      </div>
+
+      {saveError && (
+        <div
+          className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+          role="alert"
+        >
+          {saveError}
+        </div>
+      )}
+
+      <RecipeForm
+        defaultValues={initialRecipe}
+        onSubmit={handleSubmit}
+        onCancel={() => router.push(`/recipes/${recipeId}`)}
+        isSubmitting={isSubmitting}
+        submitLabel="Zapisz zmiany"
+      />
+    </div>
+  );
+}

--- a/app/recipes/[id]/edit/page.tsx
+++ b/app/recipes/[id]/edit/page.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { RecipeSchema, type Recipe } from "@/lib/schemas/recipe";
+import { createClient } from "@/lib/supabase/server";
+import { Button } from "@/components/ui/button";
+import { EditRecipeFormClient } from "./EditRecipeFormClient";
+
+export default async function EditRecipePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const { data: row, error } = await supabase
+    .from("recipes")
+    .select("id, title, ingredients, steps, notes")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error || !row) {
+    notFound();
+  }
+
+  const candidate: Recipe = {
+    title: row.title,
+    ingredients: row.ingredients as Recipe["ingredients"],
+    steps: row.steps as Recipe["steps"],
+    notes: row.notes ?? null,
+  };
+
+  const parsed = RecipeSchema.safeParse(candidate);
+  if (!parsed.success) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="mx-auto max-w-3xl space-y-4 rounded-xl border border-destructive/20 bg-destructive/5 p-6">
+          <h1 className="text-lg text-destructive">
+            Nie można wczytać przepisu do edycji
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Dane w bazie nie pasują do oczekiwanego formatu. Skontaktuj się z
+            administratorem albo dodaj przepis ponownie.
+          </p>
+          <Button asChild variant="outline">
+            <Link href={`/recipes/${id}`}>Wróć do widoku</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="mx-auto max-w-3xl">
+        <EditRecipeFormClient recipeId={row.id} initialRecipe={parsed.data} />
+      </div>
+    </div>
+  );
+}

--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { RecipeDetail } from "@/components/RecipeDetail";
+import { displayRecipeSource } from "@/lib/recipes/displaySource";
 import { createClient } from "@/lib/supabase/server";
 
 export default async function RecipePage({
@@ -27,7 +28,11 @@ export default async function RecipePage({
     steps: row.steps,
     notes: row.notes,
     isSeed: row.is_seed,
-    source: row.source_image_url ? ("scan" as const) : undefined,
+    source: displayRecipeSource({
+      is_seed: row.is_seed,
+      source_image_url: row.source_image_url,
+      entry_source: row.entry_source,
+    }),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/app/recipes/new/NewRecipePageClient.tsx
+++ b/app/recipes/new/NewRecipePageClient.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { AlertCircle, Loader2 } from "lucide-react";
+import { NewRecipeChoice } from "@/components/NewRecipeChoice";
+import { RecipeForm } from "@/components/RecipeForm";
+import { Button } from "@/components/ui/button";
+import { createClient } from "@/lib/supabase/client";
+import type { Recipe } from "@/lib/schemas/recipe";
+
+function isManualMode(searchParams: URLSearchParams) {
+  return (
+    searchParams.get("mode") === "manual" ||
+    searchParams.get("manual") === "true"
+  );
+}
+
+/**
+ * Strona /recipes/new — logika kliencka.
+ *
+ * Stany na jednym URL:
+ * 1. Choice — brak trybu manual i brak wyniku skanu
+ * 2. Parsing — fetch do /api/parse-recipe
+ * 3. Form — po skanie (defaultValues + fromScan) albo ręcznie (?mode=manual lub ?manual=true)
+ */
+export function NewRecipePageClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const manual = isManualMode(searchParams);
+
+  const [parsing, setParsing] = useState(false);
+  const [parsedRecipe, setParsedRecipe] = useState<Recipe | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleScanFile = async (file: File) => {
+    setParsing(true);
+    setError(null);
+
+    try {
+      const formData = new FormData();
+      formData.append("image", file);
+
+      const res = await fetch("/api/parse-recipe", {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
+        throw new Error(
+          body?.error ?? "Nie udało się odczytać przepisu z tego zdjęcia."
+        );
+      }
+
+      const data: Recipe = await res.json();
+      setParsedRecipe(data);
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : "Coś poszło nie tak. Spróbuj ponownie."
+      );
+    } finally {
+      setParsing(false);
+    }
+  };
+
+  const handleSave = async (data: Recipe, entrySource: "manual" | "scan") => {
+    setSubmitError(null);
+    setIsSubmitting(true);
+    try {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        setSubmitError(
+          "Brak sesji — odśwież stronę i spróbuj ponownie zapisać przepis."
+        );
+        return;
+      }
+
+      const { data: row, error: insertError } = await supabase
+        .from("recipes")
+        .insert({
+          user_id: user.id,
+          title: data.title,
+          ingredients: data.ingredients,
+          steps: data.steps,
+          notes: data.notes,
+          is_seed: false,
+          entry_source: entrySource,
+        })
+        .select("id")
+        .single();
+
+      if (insertError) {
+        setSubmitError(insertError.message);
+        return;
+      }
+
+      router.push(`/recipes/${row.id}`);
+      router.refresh();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (parsing) {
+    return (
+      <div className="mx-auto flex max-w-md flex-col items-center justify-center py-20 text-center">
+        <Loader2 className="mb-4 h-8 w-8 animate-spin text-blue-600" />
+        <p className="text-base font-semibold">Claude czyta przepis…</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          To zajmie kilka sekund. Nie zamykaj strony.
+        </p>
+      </div>
+    );
+  }
+
+  if (parsedRecipe) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-4">
+        {submitError && (
+          <div
+            className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+            role="alert"
+          >
+            {submitError}
+          </div>
+        )}
+        <RecipeForm
+          defaultValues={parsedRecipe}
+          fromScan
+          onSubmit={(d) => handleSave(d, "scan")}
+          onCancel={() => setParsedRecipe(null)}
+          isSubmitting={isSubmitting}
+        />
+      </div>
+    );
+  }
+
+  if (manual) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-4">
+        {submitError && (
+          <div
+            className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+            role="alert"
+          >
+            {submitError}
+          </div>
+        )}
+        <RecipeForm
+          onSubmit={(d) => handleSave(d, "manual")}
+          onCancel={() => router.push("/recipes/new")}
+          isSubmitting={isSubmitting}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {error && (
+        <div className="mx-auto mb-4 flex max-w-3xl flex-col gap-3 rounded-md border border-destructive/20 bg-destructive/5 p-3 sm:flex-row sm:items-start">
+          <div className="flex flex-1 gap-2">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium text-destructive">{error}</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Możesz spróbować jeszcze raz albo{" "}
+                <Link
+                  href="/recipes/new?mode=manual"
+                  className="font-medium text-foreground underline underline-offset-2 hover:no-underline"
+                >
+                  dodać przepis ręcznie
+                </Link>
+                .
+              </p>
+            </div>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="shrink-0 self-end sm:self-start"
+            onClick={() => setError(null)}
+          >
+            Zamknij
+          </Button>
+        </div>
+      )}
+      <NewRecipeChoice onScanFile={handleScanFile} />
+    </>
+  );
+}

--- a/app/recipes/new/page.tsx
+++ b/app/recipes/new/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from "react";
+import { Loader2 } from "lucide-react";
+import { NewRecipePageClient } from "./NewRecipePageClient";
+
+function NewRecipeFallback() {
+  return (
+    <div className="mx-auto flex max-w-3xl justify-center py-16">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+    </div>
+  );
+}
+
+export default function NewRecipePage() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <Suspense fallback={<NewRecipeFallback />}>
+        <NewRecipePageClient />
+      </Suspense>
+    </div>
+  );
+}

--- a/app/recipes/page.tsx
+++ b/app/recipes/page.tsx
@@ -1,5 +1,9 @@
 import { RecipeCard } from "@/components/RecipeCard";
+import { Button } from "@/components/ui/button";
+import { displayRecipeSource } from "@/lib/recipes/displaySource";
 import { createClient } from "@/lib/supabase/server";
+import { Plus } from "lucide-react";
+import Link from "next/link";
 
 export default async function RecipesPage() {
   const supabase = await createClient();
@@ -18,12 +22,23 @@ export default async function RecipesPage() {
     steps: row.steps,
     notes: row.notes,
     isSeed: row.is_seed,
-    source: row.source_image_url ? ("scan" as const) : undefined,
+    source: displayRecipeSource({
+      is_seed: row.is_seed,
+      source_image_url: row.source_image_url,
+      entry_source: row.entry_source,
+    }),
   }));
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="mb-6 text-2xl font-medium">Moje przepisy</h1>
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <h1 className="text-2xl">Moje przepisy</h1>
+        <Button size="icon" asChild aria-label="Dodaj przepis">
+          <Link href="/recipes/new">
+            <Plus />
+          </Link>
+        </Button>
+      </div>
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
         {recipes.map((recipe) => (
           <RecipeCard key={recipe.id} recipe={recipe} />

--- a/components/IngredientsArray.tsx
+++ b/components/IngredientsArray.tsx
@@ -64,37 +64,8 @@ export function IngredientsArray({
       <div className="space-y-2">
         {fields.map((field, index) => (
           <div key={field.id}>
-            {/* Desktop: jeden wiersz z trzema polami */}
-            <div className="hidden grid-cols-[80px_140px_1fr_36px] gap-2 sm:grid">
-              <Input
-                type="number"
-                step="0.25"
-                placeholder="ilość"
-                {...register(`ingredients.${index}.amount`, {
-                  setValueAs: (v) =>
-                    v === "" || v === null ? null : Number(v),
-                })}
-              />
-              <UnitSelect control={control} index={index} />
-              <Input
-                placeholder="np. mąki"
-                {...register(`ingredients.${index}.name`)}
-              />
-              <Button
-                type="button"
-                variant="outline"
-                size="icon"
-                aria-label="Usuń składnik"
-                onClick={() => remove(index)}
-                disabled={fields.length === 1}
-              >
-                <X className="h-3.5 w-3.5" />
-              </Button>
-            </div>
-
-            {/* Mobile: mini-karta z trzema wierszami */}
-            <div className="rounded-lg bg-muted p-3 sm:hidden">
-              <div className="mb-2 flex items-center justify-between">
+            <div className="rounded-lg bg-muted p-3">
+              <div className="mb-2 flex items-center justify-between sm:hidden">
                 <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
                   Składnik {index + 1}
                 </span>
@@ -110,22 +81,40 @@ export function IngredientsArray({
                   <X className="h-3 w-3" />
                 </Button>
               </div>
-              <div className="mb-2 grid grid-cols-[80px_1fr] gap-2">
+
+              <div className="flex flex-col gap-2 sm:grid sm:grid-cols-[80px_140px_minmax(0,1fr)_36px] sm:items-center">
+                <div className="flex flex-row gap-2 sm:contents">
+                  <Input
+                    type="number"
+                    step="0.25"
+                    placeholder="ilość"
+                    className="w-[5.5rem] shrink-0 sm:w-full"
+                    {...register(`ingredients.${index}.amount`, {
+                      setValueAs: (v) =>
+                        v === "" || v === null ? null : Number(v),
+                    })}
+                  />
+                  <div className="min-w-0 flex-1 sm:w-full">
+                    <UnitSelect control={control} index={index} />
+                  </div>
+                </div>
                 <Input
-                  type="number"
-                  step="0.25"
-                  placeholder="ilość"
-                  {...register(`ingredients.${index}.amount`, {
-                    setValueAs: (v) =>
-                      v === "" || v === null ? null : Number(v),
-                  })}
+                  placeholder="np. mąki"
+                  className="min-w-0 w-full sm:min-w-0"
+                  {...register(`ingredients.${index}.name`)}
                 />
-                <UnitSelect control={control} index={index} />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="hidden shrink-0 sm:flex"
+                  aria-label="Usuń składnik"
+                  onClick={() => remove(index)}
+                  disabled={fields.length === 1}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </Button>
               </div>
-              <Input
-                placeholder="np. mąki"
-                {...register(`ingredients.${index}.name`)}
-              />
             </div>
 
             {errors.ingredients?.[index]?.name && (

--- a/components/NewRecipeChoice.tsx
+++ b/components/NewRecipeChoice.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft, Camera, ChevronRight, Pencil, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ScanButton } from "@/components/ScanButton";
+import { cn } from "@/lib/utils";
+
+interface NewRecipeChoiceProps {
+  /** Callback gdy user wybierze plik do skanowania. */
+  onScanFile: (file: File) => void;
+  /** Link do formularza ręcznego (domyślnie `?mode=manual`; obsługiwane jest też `?manual=true` na stronie). */
+  manualHref?: string;
+  /** Link wstecz (domyślnie lista przepisów). */
+  backHref?: string;
+  /**
+   * Niebieska karta skanu vs obie neutralne.
+   * Ustaw `false`, żeby oba kafelki wyglądały tak samo (np. równouprawnienie opcji).
+   */
+  featured?: boolean;
+}
+
+/**
+ * Ekran wyboru sposobu dodawania przepisu — pierwszy widok po „+”.
+ *
+ * Desktop: dwie kolumny; mobile: jedna kolumna (stack).
+ * U góry: przycisk Wstecz + breadcrumb (Moje przepisy → Nowy).
+ */
+export function NewRecipeChoice({
+  onScanFile,
+  manualHref = "/recipes/new?mode=manual",
+  backHref = "/recipes",
+  featured = true,
+}: NewRecipeChoiceProps) {
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Button asChild variant="ghost" size="sm" className="w-fit shrink-0">
+          <Link href={backHref}>
+            <ArrowLeft className="mr-1.5 h-3.5 w-3.5" />
+            Wstecz
+          </Link>
+        </Button>
+        <nav
+          aria-label="Ścieżka nawigacji"
+          className="text-sm text-muted-foreground sm:text-right"
+        >
+          <ol className="flex flex-wrap items-center gap-1">
+            <li>
+              <Link
+                href="/recipes"
+                className="hover:text-foreground hover:underline"
+              >
+                Moje przepisy
+              </Link>
+            </li>
+            <li className="flex items-center gap-1" aria-hidden>
+              <ChevronRight className="h-3.5 w-3.5 opacity-60" />
+            </li>
+            <li className="font-medium text-foreground" aria-current="page">
+              Nowy
+            </li>
+          </ol>
+        </nav>
+      </div>
+
+      <div>
+        <h1 className="mb-1 text-xl">Dodaj nowy przepis</h1>
+        <p className="text-sm text-muted-foreground">
+          Wybierz, jak chcesz go dodać.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <ScanButton
+          aria-label="Zeskanuj zdjęcie przepisu — wybierz plik lub zrób zdjęcie"
+          onFileSelected={onScanFile}
+          className={cn(
+            "group flex h-full flex-col items-center rounded-xl p-6 text-center transition-all hover:-translate-y-0.5",
+            featured
+              ? "border-2 border-blue-200 bg-blue-50/40 hover:border-blue-300 hover:bg-blue-50/60 data-[drag-over=true]:border-blue-500 data-[drag-over=true]:bg-blue-100"
+              : "border bg-card hover:border-foreground/20 hover:shadow-sm data-[drag-over=true]:border-foreground/30 data-[drag-over=true]:bg-muted/60"
+          )}
+        >
+          <div
+            className={cn(
+              "mb-3 flex h-12 w-12 items-center justify-center rounded-full",
+              featured
+                ? "bg-blue-100 text-blue-700"
+                : "bg-muted text-muted-foreground"
+            )}
+          >
+            <Camera className="h-5 w-5" />
+          </div>
+          <h3 className="mb-1.5 text-base">Zeskanuj zdjęcie</h3>
+          <p className="mb-3 text-sm leading-relaxed text-muted-foreground">
+            Sfotografuj zeszyt albo wgraj plik z dysku. Claude odczyta przepis i
+            wypełni formularz za Ciebie.
+          </p>
+          <span className="mt-auto inline-flex items-center gap-1 rounded-md bg-violet-100 px-2 py-0.5 text-xs font-medium text-violet-800">
+            <Sparkles className="h-3 w-3" />
+            Powered by Claude
+          </span>
+        </ScanButton>
+
+        <Link
+          href={manualHref}
+          className="group flex h-full flex-col items-center rounded-xl border bg-card p-6 text-center transition-all hover:-translate-y-0.5 hover:border-foreground/20 hover:shadow-sm"
+        >
+          <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <Pencil className="h-5 w-5" />
+          </div>
+          <h3 className="mb-1.5 text-base">Wpisz ręcznie</h3>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            Wypełnij formularz krok po kroku — tytuł, składniki, sposób
+            przygotowania, notatki.
+          </p>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/RecipeCard.tsx
+++ b/components/RecipeCard.tsx
@@ -1,13 +1,7 @@
 import Link from "next/link";
-import {
-  BookOpen,
-  Camera,
-  List,
-  ListChecks,
-  Pencil,
-  Trash2,
-} from "lucide-react";
+import { BookOpen, Camera, List, ListChecks, Pencil } from "lucide-react";
 import { Badge, Button, Card, CardContent } from "@/components/ui";
+import { RecipeDeleteDialog } from "@/components/RecipeDeleteDialog";
 import type { Recipe } from "@/lib/schemas/recipe";
 
 export type RecipeCardData = Recipe & {
@@ -18,15 +12,14 @@ export type RecipeCardData = Recipe & {
 
 interface RecipeCardProps {
   recipe: RecipeCardData;
-  onDelete?: (id: string) => void;
 }
 
-export function RecipeCard({ recipe, onDelete }: RecipeCardProps) {
+export function RecipeCard({ recipe }: RecipeCardProps) {
   return (
     <Card className="flex h-full flex-col transition-shadow hover:shadow-md">
       <CardContent className="flex h-full flex-col p-5">
         <Link href={`/recipes/${recipe.id}`} className="group mb-2 block">
-          <h3 className="text-base font-medium leading-tight group-hover:underline">
+          <h3 className="text-base leading-tight group-hover:underline">
             {recipe.title}
           </h3>
         </Link>
@@ -47,6 +40,16 @@ export function RecipeCard({ recipe, onDelete }: RecipeCardProps) {
             className="mb-3 self-start bg-violet-50 text-violet-800 hover:bg-violet-50"
           >
             <Camera className="mr-1 h-3 w-3" />Z aparatu
+          </Badge>
+        )}
+
+        {recipe.source === "manual" && (
+          <Badge
+            variant="secondary"
+            className="mb-3 self-start bg-rose-50 text-rose-900 hover:bg-rose-50"
+          >
+            <Pencil className="mr-1 h-3 w-3" />
+            Wpisany ręcznie
           </Badge>
         )}
 
@@ -76,17 +79,12 @@ export function RecipeCard({ recipe, onDelete }: RecipeCardProps) {
                 <Pencil className="h-3.5 w-3.5" />
               </Link>
             </Button>
-            {onDelete && (
-              <Button
-                variant="outline"
-                size="icon"
-                className="h-8 w-8"
-                aria-label="Usuń przepis"
-                onClick={() => onDelete(recipe.id)}
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-              </Button>
-            )}
+            <RecipeDeleteDialog
+              recipeId={recipe.id}
+              recipeTitle={recipe.title}
+              afterDelete="refresh"
+              triggerClassName="h-8 w-8"
+            />
           </div>
         </div>
       </CardContent>

--- a/components/RecipeDeleteDialog.tsx
+++ b/components/RecipeDeleteDialog.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { AlertDialog } from "radix-ui";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { createClient } from "@/lib/supabase/client";
+import { cn } from "@/lib/utils";
+
+interface RecipeDeleteDialogProps {
+  recipeId: string;
+  recipeTitle: string;
+  /** Klasy na przycisku triggera (np. `h-8 w-8` na karcie listy). */
+  triggerClassName?: string;
+  /**
+   * `go-to-list` — po sukcesie przejście na /recipes (np. widok szczegółów).
+   * `refresh` — tylko router.refresh() (np. już jesteś na liście).
+   */
+  afterDelete?: "go-to-list" | "refresh";
+}
+
+/**
+ * Ikona kosza + AlertDialog z potwierdzeniem usunięcia przepisu z Supabase.
+ */
+export function RecipeDeleteDialog({
+  recipeId,
+  recipeTitle,
+  triggerClassName,
+  afterDelete = "go-to-list",
+}: RecipeDeleteDialogProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDelete = async () => {
+    setError(null);
+    setIsDeleting(true);
+    try {
+      const supabase = createClient();
+      const { error: deleteError } = await supabase
+        .from("recipes")
+        .delete()
+        .eq("id", recipeId);
+
+      if (deleteError) {
+        setError(deleteError.message);
+        return;
+      }
+
+      setOpen(false);
+      if (afterDelete === "refresh") {
+        router.refresh();
+      } else {
+        router.push("/recipes");
+        router.refresh();
+      }
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <AlertDialog.Root open={open} onOpenChange={setOpen}>
+      <AlertDialog.Trigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className={cn(triggerClassName)}
+          aria-label="Usuń przepis"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </Button>
+      </AlertDialog.Trigger>
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay
+          className={cn(
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=open]:animate-in"
+          )}
+        />
+        <AlertDialog.Content
+          className={cn(
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border bg-card p-6 text-card-foreground shadow-lg duration-200 data-[state=closed]:animate-out data-[state=open]:animate-in"
+          )}
+        >
+          <div className="flex flex-col gap-2">
+            <AlertDialog.Title className="text-lg">
+              Usunąć ten przepis?
+            </AlertDialog.Title>
+            <AlertDialog.Description className="text-sm text-muted-foreground">
+              Czy na pewno chcesz usunąć przepis „{recipeTitle}”? Tej operacji
+              nie da się cofnąć.
+            </AlertDialog.Description>
+          </div>
+
+          {error && (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          )}
+
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+            <AlertDialog.Cancel asChild>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isDeleting}
+              >
+                Anuluj
+              </Button>
+            </AlertDialog.Cancel>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={isDeleting}
+              onClick={handleDelete}
+            >
+              {isDeleting ? "Usuwanie…" : "Usuń przepis"}
+            </Button>
+          </div>
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
+  );
+}

--- a/components/RecipeDetail.tsx
+++ b/components/RecipeDetail.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
-import { BookOpen, Camera, Pencil, Trash2 } from "lucide-react";
+import { ArrowLeft, BookOpen, Camera, Pencil } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { RecipeDeleteDialog } from "@/components/RecipeDeleteDialog";
 import { formatIngredient } from "@/lib/units";
 import type { RecipeCardData } from "@/components/RecipeCard";
 
@@ -10,99 +11,110 @@ interface RecipeDetailProps {
     createdAt: string | Date;
     updatedAt?: string | Date | null;
   };
-  onDelete?: (id: string) => void;
 }
 
-export function RecipeDetail({ recipe, onDelete }: RecipeDetailProps) {
+export function RecipeDetail({ recipe }: RecipeDetailProps) {
   return (
-    <article className="rounded-xl border bg-card p-6 md:p-8">
-      <header className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h1 className="mb-2 text-2xl font-medium leading-tight">
-            {recipe.title}
-          </h1>
-          <div className="flex flex-wrap gap-2">
-            {recipe.isSeed && (
-              <Badge
-                variant="secondary"
-                className="bg-emerald-50 text-emerald-800 hover:bg-emerald-50"
-              >
-                <BookOpen className="mr-1 h-3 w-3" />
-                Przykład
-              </Badge>
-            )}
-            {recipe.source === "scan" && (
-              <Badge
-                variant="secondary"
-                className="bg-violet-50 text-violet-800 hover:bg-violet-50"
-              >
-                <Camera className="mr-1 h-3 w-3" />
-                Z aparatu
-              </Badge>
-            )}
+    <div className="space-y-4">
+      <Button asChild variant="ghost" size="sm" className="-ml-2 w-fit">
+        <Link href="/recipes">
+          <ArrowLeft className="mr-1.5 h-3.5 w-3.5" />
+          Moje przepisy
+        </Link>
+      </Button>
+
+      <article className="rounded-xl border bg-card p-6 md:p-8">
+        <header className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h1 className="mb-2 text-2xl leading-tight">
+              {recipe.title}
+            </h1>
+            <div className="flex flex-wrap gap-2">
+              {recipe.isSeed && (
+                <Badge
+                  variant="secondary"
+                  className="bg-emerald-50 text-emerald-800 hover:bg-emerald-50"
+                >
+                  <BookOpen className="mr-1 h-3 w-3" />
+                  Przykład
+                </Badge>
+              )}
+              {recipe.source === "scan" && (
+                <Badge
+                  variant="secondary"
+                  className="bg-violet-50 text-violet-800 hover:bg-violet-50"
+                >
+                  <Camera className="mr-1 h-3 w-3" />
+                  Z aparatu
+                </Badge>
+              )}
+              {recipe.source === "manual" && (
+                <Badge
+                  variant="secondary"
+                  className="bg-rose-50 text-rose-900 hover:bg-rose-50"
+                >
+                  <Pencil className="mr-1 h-3 w-3" />
+                  Wpisany ręcznie
+                </Badge>
+              )}
+            </div>
           </div>
-        </div>
-        <div className="flex shrink-0 gap-2">
-          <Button asChild variant="outline" size="sm">
-            <Link href={`/recipes/${recipe.id}/edit`}>
-              <Pencil className="mr-2 h-3.5 w-3.5" />
-              Edytuj
-            </Link>
-          </Button>
-          {onDelete && (
-            <Button
-              variant="outline"
-              size="icon"
-              aria-label="Usuń przepis"
-              onClick={() => onDelete(recipe.id)}
-            >
-              <Trash2 className="h-3.5 w-3.5" />
+          <div className="flex shrink-0 gap-2">
+            <Button asChild variant="outline" size="sm">
+              <Link href={`/recipes/${recipe.id}/edit`}>
+                <Pencil className="mr-2 h-3.5 w-3.5" />
+                Edytuj
+              </Link>
             </Button>
-          )}
-        </div>
-      </header>
+            <RecipeDeleteDialog
+              recipeId={recipe.id}
+              recipeTitle={recipe.title}
+            />
+          </div>
+        </header>
 
-      <section className="mb-6">
-        <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          Składniki
-        </h2>
-        <ul className="list-disc space-y-1.5 pl-5 text-sm leading-relaxed">
-          {recipe.ingredients.map((ing, i) => (
-            <li key={i}>{formatIngredient(ing)}</li>
-          ))}
-        </ul>
-      </section>
-
-      <section className="mb-6">
-        <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          Sposób przygotowania
-        </h2>
-        <ol className="list-decimal space-y-2 pl-5 text-sm leading-relaxed">
-          {recipe.steps.map((step, i) => (
-            <li key={i}>{step.value}</li>
-          ))}
-        </ol>
-      </section>
-
-      {recipe.notes && (
-        <section className="rounded-lg bg-muted p-4">
-          <h2 className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-            Notatki
+        <section className="mb-6">
+          <h2 className="mb-3 text-xs uppercase tracking-wider text-muted-foreground">
+            Składniki
           </h2>
-          <p className="text-sm italic leading-relaxed">„{recipe.notes}”</p>
+          <ul className="list-disc space-y-1.5 pl-5 text-sm leading-relaxed">
+            {recipe.ingredients.map((ing, i) => (
+              <li key={i}>{formatIngredient(ing)}</li>
+            ))}
+          </ul>
         </section>
-      )}
 
-      <footer className="mt-6 flex flex-wrap items-center gap-x-2 gap-y-1 border-t pt-4 text-xs text-muted-foreground">
-        <span>Dodano {formatDate(recipe.createdAt)}</span>
-        {recipe.updatedAt && (
-          <>
-            <span>·</span>
-            <span>Edytowane {formatDate(recipe.updatedAt)}</span>
-          </>
+        <section className="mb-6">
+          <h2 className="mb-3 text-xs uppercase tracking-wider text-muted-foreground">
+            Sposób przygotowania
+          </h2>
+          <ol className="list-decimal space-y-2 pl-5 text-sm leading-relaxed">
+            {recipe.steps.map((step, i) => (
+              <li key={i}>{step.value}</li>
+            ))}
+          </ol>
+        </section>
+
+        {recipe.notes && (
+          <section className="rounded-lg bg-muted p-4">
+            <h2 className="mb-2 text-xs uppercase tracking-wider text-muted-foreground">
+              Notatki
+            </h2>
+            <p className="text-sm italic leading-relaxed">„{recipe.notes}”</p>
+          </section>
         )}
-      </footer>
-    </article>
+
+        <footer className="mt-6 flex flex-wrap items-center gap-x-2 gap-y-1 border-t pt-4 text-xs text-muted-foreground">
+          <span>Dodano {formatDate(recipe.createdAt)}</span>
+          {recipe.updatedAt && (
+            <>
+              <span>·</span>
+              <span>Edytowane {formatDate(recipe.updatedAt)}</span>
+            </>
+          )}
+        </footer>
+      </article>
+    </div>
   );
 }
 

--- a/components/ScanButton.tsx
+++ b/components/ScanButton.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import {
+  useRef,
+  useState,
+  type ComponentProps,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/utils";
+
+interface ScanButtonProps
+  extends Omit<ComponentProps<"button">, "type" | "onClick"> {
+  /** Callback z wybranym/upuszczonym plikiem obrazu. */
+  onFileSelected: (file: File) => void;
+  /**
+   * Zawartość przycisku (ikona, tekst, cała karta — cokolwiek).
+   * Cały obszar `children` jest klikalny i akceptuje drop.
+   */
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Przycisk wywołujący wybór pliku obrazu.
+ *
+ * Cechy:
+ * - Klik otwiera natywny picker (na mobile: aparat / biblioteka / pliki, na desktop: file dialog)
+ * - Drag&drop działa na desktopie (na mobile pomijane przez przeglądarkę)
+ * - Reset value po wyborze pozwala wybrać ten sam plik ponownie
+ * - Stan drag-over przekazany przez data-attribute (do stylowania w Tailwindzie)
+ *
+ * Uwaga: NIE używamy `capture="environment"` żeby user mógł wybrać między
+ * aparatem a galerią/plikami (na iOS sam picker ma trzy opcje).
+ */
+export function ScanButton({
+  onFileSelected,
+  children,
+  className,
+  disabled,
+  ...buttonProps
+}: ScanButtonProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const handleFiles = (files: FileList | null) => {
+    const file = files?.[0];
+    if (file && file.type.startsWith("image/")) {
+      onFileSelected(file);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        {...buttonProps}
+        onClick={() => inputRef.current?.click()}
+        onDragOver={(e) => {
+          e.preventDefault();
+          if (!disabled) setIsDragOver(true);
+        }}
+        onDragLeave={() => setIsDragOver(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setIsDragOver(false);
+          if (!disabled) handleFiles(e.dataTransfer.files);
+        }}
+        disabled={disabled}
+        data-drag-over={isDragOver}
+        className={cn(
+          "transition-all disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+      >
+        {children}
+      </button>
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(e) => {
+          handleFiles(e.target.files);
+          e.target.value = "";
+        }}
+      />
+    </>
+  );
+}

--- a/lib/recipes/displaySource.ts
+++ b/lib/recipes/displaySource.ts
@@ -1,0 +1,13 @@
+/**
+ * Mapowanie wiersza `recipes` → pole `source` na karcie / szczegółach.
+ * Przykłady (seed) nie dostają etykiety manual/scan — tylko badge „Przykład”.
+ */
+export function displayRecipeSource(row: {
+  is_seed: boolean;
+  source_image_url?: string | null;
+  entry_source?: string | null;
+}): "manual" | "scan" | undefined {
+  if (row.is_seed) return undefined;
+  if (row.entry_source === "scan" || row.source_image_url) return "scan";
+  return "manual";
+}

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -44,7 +44,7 @@ pnpm dlx supabase db push
 |--------|------|
 | `public.profiles` | `id`, `email`, `display_name`, `is_anonymous` (domyślnie `true` w kolumnie), `created_at`. Trigger wstawia na start `id`, `email`, `is_anonymous` z `auth.users`. |
 | Trigger `on_auth_user_created` | Po utworzeniu użytkownika (także anonymous) wstawia wiersz w `profiles`. |
-| `public.recipes` | Przepisy: `user_id`, `title`, `ingredients` / `steps` jako **jsonb** (struktura jak w `lib/schemas/recipe.ts`), `notes`, `is_seed`, opcjonalnie `source_image_url`, znaczniki czasu. |
+| `public.recipes` | Przepisy: `user_id`, `title`, `ingredients` / `steps` jako **jsonb** (struktura jak w `lib/schemas/recipe.ts`), `notes`, `is_seed`, opcjonalnie `source_image_url`, kolumna `entry_source` (`manual` / `scan`, migracja `20260530120000_recipes_entry_source.sql`), znaczniki czasu. |
 | Trigger `recipes_set_updated_at` | Przed `update` na `recipes` ustawia `updated_at`. |
 | RLS | `profiles` i `recipes` — **authenticated** widzi i modyfikuje tylko własne dane (`auth.uid()`). |
 | `grant … authenticated` | Jawne uprawnienia do `select`/`update` na `profiles` oraz pełny CRUD na `recipes` (RLS i tak filtruje). |

--- a/supabase/migrations/20260530120000_recipes_entry_source.sql
+++ b/supabase/migrations/20260530120000_recipes_entry_source.sql
@@ -1,0 +1,6 @@
+-- Źródło dodania przepisu (badge: ręcznie vs skan).
+alter table public.recipes
+  add column if not exists entry_source text;
+
+comment on column public.recipes.entry_source is
+  'manual | scan — ustawiane przy insert; null = starsze wiersze (traktujemy jak manual w UI).';


### PR DESCRIPTION
Add /recipes/new with manual vs scan choice, stub parse-recipe API, and Supabase inserts including entry_source. Add edit page, delete confirmation on list and detail, plus button on the list, and back link from detail. Show a rose badge for manually entered recipes. Fix duplicate react-hook-form registration in IngredientsArray. Default h1–h6 to semibold in globals. Document entry_source migration in Supabase README.